### PR TITLE
fix error saving key (ios)

### DIFF
--- a/src/ios/SecureKeyStore.m
+++ b/src/ios/SecureKeyStore.m
@@ -57,7 +57,7 @@
     {
         NSLog(@"Read exception: %@", exception);
     }
-    return dict;
+    return [dict mutableCopy];
 }
 
 - (BOOL) removeKeyFromSecureKeyStore:(NSString*) key


### PR DESCRIPTION
Error: mutating method sent to immutable object.

```js
var now = (new Date()).toString();
cordova.plugins.SecureKeyStore.set(
    function (res) {},
    function (error) {
        console.log(error); // Error!!
    },
    "key1",
    now
);
```

```
{"code":9,"message":"error saving key, 
please try to un-install and re-install app again",
"actual-error":-[__NSCFDictionary setObject:forKey:]: 
mutating method sent to immutable object}
```