### PR TITLE
Added quotes around error messages

### DIFF
--- a/src/android/SecureKeyStore.java
+++ b/src/android/SecureKeyStore.java
@@ -103,7 +103,7 @@ public class SecureKeyStore extends CordovaPlugin {
         } catch (Exception e) {
             Log.e(Constants.TAG, "Exception: " + e.getMessage());
             callbackContext.error(
-                    "{\"code\":9,\"api-level\":" + Build.VERSION.SDK_INT + ",\"message\":" + e.getMessage() + "}");
+                    "{\"code\": 9,\"api-level\": " + Build.VERSION.SDK_INT + ",\"message\": \"" + e.getMessage() + "\"}");
         }
 
     }
@@ -137,7 +137,7 @@ public class SecureKeyStore extends CordovaPlugin {
         } catch (Exception e) {
             Log.e(Constants.TAG, "Exception: " + e.getMessage());
             callbackContext.error(
-                    "{\"code\":1,\"api-level\":" + Build.VERSION.SDK_INT + ",\"message\":" + e.getMessage() + "}");
+                    "{\"code\": 1,\"api-level\": " + Build.VERSION.SDK_INT + ",\"message\": \"" + e.getMessage() + "\"}");
         }
     }
 
@@ -150,7 +150,7 @@ public class SecureKeyStore extends CordovaPlugin {
         } catch (Exception e) {
             Log.e(Constants.TAG, "Exception: " + e.getMessage());
             callbackContext.error(
-                    "{\"code\":6,\"api-level\":" + Build.VERSION.SDK_INT + ",\"message\":" + e.getMessage() + "}");
+                    "{\"code\": 6,\"api-level\": " + Build.VERSION.SDK_INT + ",\"message\": \"" + e.getMessage() + "\"}");
         }
     }
 

--- a/src/android/SecureKeyStore.java
+++ b/src/android/SecureKeyStore.java
@@ -103,7 +103,7 @@ public class SecureKeyStore extends CordovaPlugin {
         } catch (Exception e) {
             Log.e(Constants.TAG, "Exception: " + e.getMessage());
             callbackContext.error(
-                    "{\"code\": 9,\"api-level\": " + Build.VERSION.SDK_INT + ",\"message\": \"" + e.getMessage() + "\"}");
+                    "{\"code\": 9, \"api-level\": " + Build.VERSION.SDK_INT + ",\"message\": \"" + e.getMessage() + "\"}");
         }
 
     }
@@ -137,7 +137,7 @@ public class SecureKeyStore extends CordovaPlugin {
         } catch (Exception e) {
             Log.e(Constants.TAG, "Exception: " + e.getMessage());
             callbackContext.error(
-                    "{\"code\": 1,\"api-level\": " + Build.VERSION.SDK_INT + ",\"message\": \"" + e.getMessage() + "\"}");
+                    "{\"code\": 1, \"api-level\": " + Build.VERSION.SDK_INT + ", \"message\": \"" + e.getMessage() + "\"}");
         }
     }
 
@@ -150,7 +150,7 @@ public class SecureKeyStore extends CordovaPlugin {
         } catch (Exception e) {
             Log.e(Constants.TAG, "Exception: " + e.getMessage());
             callbackContext.error(
-                    "{\"code\": 6,\"api-level\": " + Build.VERSION.SDK_INT + ",\"message\": \"" + e.getMessage() + "\"}");
+                    "{\"code\": 6, \"api-level\": " + Build.VERSION.SDK_INT + ", \"message\": \"" + e.getMessage() + "\"}");
         }
     }
 


### PR DESCRIPTION
Without quotes around strings, JSON.parse in javascript side throws errors.